### PR TITLE
Optimize trade metrics processing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1042,7 +1042,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1482,7 +1481,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001718",
         "electron-to-chromium": "^1.5.160",
@@ -1619,7 +1617,6 @@
       "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
       "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
@@ -1819,7 +1816,6 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
       "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -2178,7 +2174,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -2347,7 +2342,6 @@
       "integrity": "sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.8",
@@ -4505,7 +4499,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -4657,7 +4650,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4680,7 +4672,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -5627,7 +5618,6 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5797,7 +5787,6 @@
       "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/components/MakerTakerPie.tsx
+++ b/src/components/MakerTakerPie.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Chart as ChartJS, ArcElement, Tooltip, Legend } from 'chart.js';
 import { Pie } from 'react-chartjs-2';
 import { MatchedTrade } from '@/utils/processData';
@@ -12,14 +12,15 @@ interface MakerTakerPieProps {
 }
 
 export default function MakerTakerPie({ matchedTrades }: MakerTakerPieProps) {
-  // Maker = 0 entry fees (providing liquidity), Taker = has entry fees (taking liquidity)
-  const makerContracts = matchedTrades
-    .filter(t => t.Entry_Fee === 0)
-    .reduce((sum, t) => sum + t.Contracts, 0);
-  
-  const takerContracts = matchedTrades
-    .filter(t => t.Entry_Fee > 0)
-    .reduce((sum, t) => sum + t.Contracts, 0);
+  const { makerContracts, takerContracts } = useMemo(() => {
+    let makerContracts = 0;
+    let takerContracts = 0;
+    for (const t of matchedTrades) {
+      if (t.Entry_Fee === 0) makerContracts += t.Contracts;
+      else takerContracts += t.Contracts;
+    }
+    return { makerContracts, takerContracts };
+  }, [matchedTrades]);
 
   const data = {
     labels: ['Maker (0 fees)', 'Taker (paid fees)'],

--- a/src/components/Overview.tsx
+++ b/src/components/Overview.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import React, { useMemo } from 'react';
 import { MatchedTrade } from '@/utils/processData';
 
 interface OverviewProps {
@@ -56,38 +56,37 @@ export default function Overview({ stats, matchedTrades }: OverviewProps) {
     return value.toFixed(1) + ' days';
   };
 
-  // Calculate total risked (entry cost) and average PNL per dollar risked
-  const totalRisked = matchedTrades.reduce((sum, trade) => sum + trade.Entry_Cost, 0);
-  const totalProfit = matchedTrades.reduce((sum, trade) => sum + trade.Net_Profit, 0);
-  const avgPnlPerDollarRisked = totalRisked > 0 ? totalProfit / totalRisked : 0;
+  const { avgPnlPerDollarRisked, maxTicker, maxProfit, minTicker, minProfit, highestROITrade, highestROI } = useMemo(() => {
+    let totalRisked = 0;
+    let totalProfit = 0;
+    const profitByTicker: Record<string, number> = {};
+    let highestROITrade: MatchedTrade | null = null;
+    let highestROI = -Infinity;
 
-  // Calculate profit by ticker using matched trades
-  const profitByTicker = matchedTrades.reduce((acc, trade) => {
-    acc[trade.Ticker] = (acc[trade.Ticker] || 0) + trade.Net_Profit;
-    return acc;
-  }, {} as Record<string, number>);
+    for (const trade of matchedTrades) {
+      totalRisked += trade.Entry_Cost;
+      totalProfit += trade.Net_Profit;
+      profitByTicker[trade.Ticker] = (profitByTicker[trade.Ticker] || 0) + trade.Net_Profit;
+      if (trade.Entry_Cost > 0) {
+        const roi = trade.ROI ?? (trade.Net_Profit / trade.Entry_Cost);
+        if (roi > highestROI) { highestROI = roi; highestROITrade = trade; }
+      }
+    }
 
-  // Find best and worst tickers
-  const entries = Object.entries(profitByTicker);
-  const [maxTicker, maxProfit] = entries.length
-    ? entries.reduce(([t, p], [t2, p2]) => (p2 > p ? [t2, p2] : [t, p]))
-    : ['N/A', 0];
-  const [minTicker, minProfit] = entries.length
-    ? entries.reduce(([t, p], [t2, p2]) => (p2 < p ? [t2, p2] : [t, p]))
-    : ['N/A', 0];
+    const entries = Object.entries(profitByTicker);
+    const [maxTicker, maxProfit] = entries.length
+      ? entries.reduce(([t, p], [t2, p2]) => (p2 > p ? [t2, p2] : [t, p]))
+      : ['N/A', 0];
+    const [minTicker, minProfit] = entries.length
+      ? entries.reduce(([t, p], [t2, p2]) => (p2 < p ? [t2, p2] : [t, p]))
+      : ['N/A', 0];
 
-  // Find highest ROI trade
-  const [highestROITrade, highestROI] = matchedTrades.reduce<[MatchedTrade | null, number]>((best, trade) => {
-    // Skip trades with zero or negative investment
-    if (trade.Entry_Cost <= 0) return best;
-    
-    const currentROI = trade.ROI || (trade.Net_Profit / trade.Entry_Cost);
-    
-    // Get previous best ROI for comparison
-    const [, bestROI] = best;
-    
-    return currentROI > bestROI ? [trade, currentROI] : best;
-  }, [null, -Infinity]);
+    return {
+      avgPnlPerDollarRisked: totalRisked > 0 ? totalProfit / totalRisked : 0,
+      maxTicker, maxProfit, minTicker, minProfit,
+      highestROITrade, highestROI: highestROI === -Infinity ? 0 : highestROI,
+    };
+  }, [matchedTrades]);
 
   return (
     <div className="mt-6">

--- a/src/components/RiskAdjustedReturns.tsx
+++ b/src/components/RiskAdjustedReturns.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 import { MatchedTrade } from '@/utils/processData';
 
 interface RiskAdjustedReturnsProps {
@@ -33,56 +33,37 @@ const calculateRiskMetrics = (matchedTrades: MatchedTrade[], initialCapital: num
   }
 
   // Get date range
-  const startDate = new Date(Math.min(...matchedTrades.map(t => t.Entry_Date.getTime())));
-  const endDate = new Date(Math.max(...matchedTrades.map(t => t.Exit_Date.getTime())));
+  const startDate = new Date(matchedTrades.reduce((min, t) => Math.min(min, t.Entry_Date.getTime()), Infinity));
+  const endDate = new Date(matchedTrades.reduce((max, t) => Math.max(max, t.Exit_Date.getTime()), -Infinity));
   
-  // Create daily portfolio value tracking
-  const portfolioValues: { [key: string]: number } = {};
-  const dateRange: Date[] = [];
-  const currentDate = new Date(startDate);
-  currentDate.setHours(0, 0, 0, 0);
-  
-  while (currentDate <= endDate) {
-    const dateKey = currentDate.toISOString().split('T')[0];
-    dateRange.push(new Date(currentDate));
-    portfolioValues[dateKey] = initialCapital; // Start with initial capital
-    currentDate.setDate(currentDate.getDate() + 1);
+  // Aggregate P&L by exit date in a single O(N) pass
+  const dailyPnl = new Map<string, number>();
+  for (const trade of matchedTrades) {
+    const key = trade.Exit_Date.toISOString().split('T')[0];
+    dailyPnl.set(key, (dailyPnl.get(key) ?? 0) + trade.Realized_Profit);
   }
 
-  // Apply P&L on exit dates using portfolio value approach
+  // Sweep date range once to build portfolio values — O(D) where D = number of days
   let cumulativeProfit = 0;
-  matchedTrades
-    .sort((a, b) => a.Exit_Date.getTime() - b.Exit_Date.getTime())
-    .forEach(trade => {
-      const exitDateKey = new Date(trade.Exit_Date).toISOString().split('T')[0];
-      cumulativeProfit += trade.Realized_Profit;
-      
-      // Update portfolio value from exit date onwards
-      let updateDate = new Date(trade.Exit_Date);
-      updateDate.setHours(0, 0, 0, 0);
-      
-      while (updateDate <= endDate) {
-        const updateDateKey = updateDate.toISOString().split('T')[0];
-        if (portfolioValues.hasOwnProperty(updateDateKey)) {
-          portfolioValues[updateDateKey] = initialCapital + cumulativeProfit;
-        }
-        updateDate.setDate(updateDate.getDate() + 1);
-      }
-    });
+  const portfolioValueArray: { date: Date; value: number }[] = [];
+  const sweepDate = new Date(startDate);
+  sweepDate.setHours(0, 0, 0, 0);
+  while (sweepDate <= endDate) {
+    const key = sweepDate.toISOString().split('T')[0];
+    cumulativeProfit += dailyPnl.get(key) ?? 0;
+    portfolioValueArray.push({ date: new Date(sweepDate), value: initialCapital + cumulativeProfit });
+    sweepDate.setDate(sweepDate.getDate() + 1);
+  }
 
   // Calculate daily returns from portfolio values
   const dailyReturns: number[] = [];
-  const portfolioValueArray = dateRange.map(date => ({
-    date,
-    value: portfolioValues[date.toISOString().split('T')[0]]
-  }));
 
   for (let i = 1; i < portfolioValueArray.length; i++) {
     const todayValue = portfolioValueArray[i].value;
     const yesterdayValue = portfolioValueArray[i - 1].value;
     
     if (yesterdayValue > 0) {
-      const dailyReturn = (todayValue - yesterdayValue) / yesterdayValue;
+      const dailyReturn = (todayValue - yesterdayValue) / initialCapital;
       dailyReturns.push(dailyReturn);
     }
   }
@@ -107,7 +88,7 @@ const calculateRiskMetrics = (matchedTrades: MatchedTrade[], initialCapital: num
   const avgDailyReturn = dailyReturns.reduce((sum, ret) => sum + ret, 0) / dailyReturns.length;
   
   // Calculate standard deviation using all daily returns
-  const variance = dailyReturns.reduce((sum, ret) => sum + Math.pow(ret - avgDailyReturn, 2), 0) / dailyReturns.length;
+  const variance = dailyReturns.reduce((sum, ret) => sum + Math.pow(ret - avgDailyReturn, 2), 0) / (dailyReturns.length - 1);
   const standardDeviation = Math.sqrt(variance);
 
   // Calculate total return from initial to final portfolio value
@@ -141,8 +122,18 @@ const calculateRiskMetrics = (matchedTrades: MatchedTrade[], initialCapital: num
 };
 
 export default function RiskAdjustedReturns({ matchedTrades }: RiskAdjustedReturnsProps) {
-  const [totalCapital, setTotalCapital] = useState<number>(10000);
-  const metrics = calculateRiskMetrics(matchedTrades, totalCapital);
+  const [inputCapital, setInputCapital] = useState<number>(10000);
+  const [debouncedCapital, setDebouncedCapital] = useState<number>(10000);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedCapital(inputCapital), 400);
+    return () => clearTimeout(timer);
+  }, [inputCapital]);
+
+  const metrics = useMemo(
+    () => calculateRiskMetrics(matchedTrades, debouncedCapital),
+    [matchedTrades, debouncedCapital]
+  );
 
   const formatPercent = (value: number) => {
     return new Intl.NumberFormat('en-US', {
@@ -170,8 +161,8 @@ export default function RiskAdjustedReturns({ matchedTrades }: RiskAdjustedRetur
             <input
               id="totalCapital"
               type="number"
-              value={totalCapital}
-              onChange={(e) => setTotalCapital(Number(e.target.value) || 0)}
+              value={inputCapital}
+              onChange={(e) => setInputCapital(Number(e.target.value) || 0)}
               className="pl-8 pr-4 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
               placeholder="10000"
               min="1"

--- a/src/components/TradeList.tsx
+++ b/src/components/TradeList.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import React, { useMemo } from 'react';
 import { MatchedTrade } from '@/utils/processData';
 
 interface TradeListProps {
@@ -8,10 +8,12 @@ interface TradeListProps {
 }
 
 export default function TradeList({ trades }: TradeListProps) {
-  // Get only the most recent 5 trades
-  const recentTrades = [...trades]
-    .sort((a, b) => new Date(b.Exit_Date).getTime() - new Date(a.Exit_Date).getTime())
-    .slice(0, 5);
+  const recentTrades = useMemo(() =>
+    [...trades]
+      .sort((a, b) => b.Exit_Date.getTime() - a.Exit_Date.getTime())
+      .slice(0, 5),
+    [trades]
+  );
 
   const formatDate = (date: Date) => {
     return new Date(date).toLocaleDateString('en-US', {

--- a/src/components/TradeSettlementPie.tsx
+++ b/src/components/TradeSettlementPie.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Chart as ChartJS, ArcElement, Tooltip, Legend } from 'chart.js';
 import { Pie } from 'react-chartjs-2';
 import { MatchedTrade } from '@/utils/processData';
@@ -12,14 +12,15 @@ interface TradeSettlementPieProps {
 }
 
 export default function TradeSettlementPie({ matchedTrades }: TradeSettlementPieProps) {
-  // Calculate the number of contracts settled vs sold (exited early)
-  const settledContracts = matchedTrades
-    .filter(t => t.Exit_Type === 'settlement')
-    .reduce((sum, t) => sum + t.Contracts, 0);
-  
-  const soldContracts = matchedTrades
-    .filter(t => t.Exit_Type !== 'settlement')
-    .reduce((sum, t) => sum + t.Contracts, 0);
+  const { settledContracts, soldContracts } = useMemo(() => {
+    let settledContracts = 0;
+    let soldContracts = 0;
+    for (const t of matchedTrades) {
+      if (t.Exit_Type === 'settlement') settledContracts += t.Contracts;
+      else soldContracts += t.Contracts;
+    }
+    return { settledContracts, soldContracts };
+  }, [matchedTrades]);
 
   const data = {
     labels: ['Settled Contracts', 'Sold Contracts'],

--- a/src/utils/processData.ts
+++ b/src/utils/processData.ts
@@ -684,13 +684,17 @@ const calculateBasicStatsFromMatchedTrades = (matchedTrades: MatchedTrade[]): Pr
     ? matchedTrades.reduce((sum, t) => sum + (t.Holding_Period_Days * t.Entry_Cost / totalTradeValue), 0)
     : 0;
   
-  // Win rates
-  const profitableTrades = matchedTrades.filter(t => t.Net_Profit > 0);
-  const settledTrades = matchedTrades.filter(t => t.Exit_Type === 'settlement');
-  const profitableSettledTrades = settledTrades.filter(t => t.Net_Profit > 0);
-  
-  const winRate = matchedTrades.length > 0 ? profitableTrades.length / matchedTrades.length : 0;
-  const settledWinRate = settledTrades.length > 0 ? profitableSettledTrades.length / settledTrades.length : 0;
+  // Win rates — single pass instead of three separate filters
+  let profitableCount = 0, settledCount = 0, profitableSettledCount = 0;
+  for (const t of matchedTrades) {
+    if (t.Net_Profit > 0) profitableCount++;
+    if (t.Exit_Type === 'settlement') {
+      settledCount++;
+      if (t.Net_Profit > 0) profitableSettledCount++;
+    }
+  }
+  const winRate = matchedTrades.length > 0 ? profitableCount / matchedTrades.length : 0;
+  const settledWinRate = settledCount > 0 ? profitableSettledCount / settledCount : 0;
   
   return {
     uniqueTickers,
@@ -802,8 +806,8 @@ export const processCSVData = (results: any): ProcessedData => {
 // Combine multiple ProcessedData objects into one
 export const combineProcessedData = (dataArray: ProcessedData[]): ProcessedData => {
   // Combine all trades and matched trades
-  const allTrades = dataArray.reduce<Trade[]>((acc, data) => [...acc, ...data.trades], []);
-  const allMatchedTrades = dataArray.reduce<MatchedTrade[]>((acc, data) => [...acc, ...data.matchedTrades], []);
+  const allTrades = dataArray.flatMap(d => d.trades);
+  const allMatchedTrades = dataArray.flatMap(d => d.matchedTrades);
   
   // Sort trades by date
   const sortedTrades = allTrades.sort((a, b) => a.Date.getTime() - b.Date.getTime());
@@ -813,7 +817,7 @@ export const combineProcessedData = (dataArray: ProcessedData[]): ProcessedData 
   const basicStats = calculateBasicStatsFromMatchedTrades(sortedMatchedTrades);
   
   // Combine original data
-  const originalData = dataArray.reduce<any[]>((acc, data) => [...acc, ...data.originalData], []);
+  const originalData = dataArray.flatMap(d => d.originalData);
   
   return {
     originalData,


### PR DESCRIPTION
Reduce repeated passes over matched trades and combined CSV data by using single-pass aggregation, flatMap merging, and memoized dashboard summaries.

Correct risk-adjusted return calculations by applying daily P&L against initial capital and using sample standard deviation for volatility/Sharpe metrics.

Debounce risk capital input changes so expensive risk metrics are not recalculated on every keystroke.